### PR TITLE
Use typescript required properties on interfaces to inform required in GQL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts2gql",
-  "version": "1.0.1",
+  "version": "2.0.1",
   "description": "Converts a TypeScript type hierarchy into GraphQL's IDL.",
   "homepage": "https://github.com/convoyinc/ts2gql",
   "bugs": "https://github.com/convoyinc/ts2gql/issues",

--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -143,6 +143,7 @@ export default class Collector {
       type: 'property',
       name: node.name.getText(),
       signature: this._walkNode(node.type),
+      hasQuestionToken: !!node.questionToken,
     };
   }
 

--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -89,6 +89,7 @@ export default class Emitter {
         type: 'property',
         name: '__placeholder',
         signature: {type: 'boolean'},
+        hasQuestionToken: false,
       });
     }
 
@@ -103,7 +104,7 @@ export default class Emitter {
         const returnType = this._emitExpression(member.returns);
         return `${this._name(member.name)}${parameters}: ${returnType}`;
       } else if (member.type === 'property') {
-        return `${this._name(member.name)}: ${this._emitExpression(member.signature)}`;
+        return `${this._name(member.name)}: ${this._emitExpression(member.signature)}${this._emitRequiredToken(member.hasQuestionToken)}`;
       } else {
         throw new Error(`Can't serialize ${member.type} as a property of an interface`);
       }
@@ -151,13 +152,17 @@ export default class Emitter {
           if (member.type !== 'property') {
             throw new Error(`Expected members of literal object to be properties; got ${member.type}`);
           }
-          return `${this._name(member.name)}: ${this._emitExpression(member.signature)}`;
+          return `${this._name(member.name)}: ${this._emitExpression(member.signature)}${this._emitRequiredToken(member.hasQuestionToken)}`;
         })
         .join(', ');
     } else {
       console.log(node);
       throw new Error(`Can't serialize ${node.type} as an expression`);
     }
+  }
+
+  _emitRequiredToken(hasQuestionToken:boolean) {
+    return !hasQuestionToken ? '!' : '';
   }
 
   // Utility

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export interface PropertyNode extends ComplexNode {
   type:'property';
   name:string;
   signature:Node;
+  hasQuestionToken:boolean;
 }
 
 export interface AliasNode extends ComplexNode {


### PR DESCRIPTION
GQL has a notion of required properties on an interface or type, we should pass Typescripts required properties (?) through to GQL (!).