### PR TITLE
Pin typescript version in ‘devDependencies’

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "tslint": "^3.13.0",
-    "typescript": "^2.0.0",
+    "typescript": "2.0.10",
     "typings": "^1.3.1"
   }
 }


### PR DESCRIPTION
Our package is currently incompatible with a few of the changes that TypeScript made to their compiler API starting in version 2.1. Let's pin our TypeScript version for now until we can make our package compatible with the latest version of TS.