### PR TITLE
Change how return types of methods are generated

### DIFF
--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -134,7 +134,7 @@ export default class Collector {
       type: 'method',
       name: node.name.getText(),
       parameters,
-      returns: this._walkType(signature.getReturnType()),
+      returns: this._walkNode(node.type),
     };
   }
 


### PR DESCRIPTION
If a method returns a non-primitive scalar, e.g. `StringMap` , we were down-converting it to its aliased primitive (a `String`). This allows us to return a defined scalar without resolving its alias.

# Compiling this...
```sh
export type Bar = string;

export interface QueryRoot {
  thing(args:{ stuff:string }):Bar;
}

export interface MutationRoot {
  thing(args:{ stuff:string }):Bar;
}

/** @graphql schema */
export interface Schema {
  query:QueryRoot;
  mutation:MutationRoot;
}
```
# This is the diff (before/after) of compiled GQL
```diff
 scalar Date

+scalar Bar
+
 type QueryRoot {
-  thing(stuff: String): String
+  thing(stuff: String): Bar
 }

 type MutationRoot {
-  thing(stuff: String): String
+  thing(stuff: String): Bar
 }

 schema {
```