### PR TITLE
Add support for string enums declared with double quotes.

### DIFF
--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -175,9 +175,14 @@ export default class Collector {
            *      CREATED  = 'CREATED',
            *      ACCEPTED = 'ACCEPTED',
            *    }
+           *
+           *    export enum Type {
+           *      CREATED  = "CREATED",
+           *      ACCEPTED = "ACCEPTED",
+           *    }
            */
           const target = _.last(m.initializer.getChildren()) || m.initializer;
-          return _.trim(target.getText(), "'");
+          return _.trim(target.getText(), "'\"");
         } else {
           /**
            *  For Enums without initializers (or with numeric literal initializers), emit the
@@ -187,7 +192,7 @@ export default class Collector {
            *      ACCEPTED,
            *    }
            */
-          return _.trim(m.name.getText(), "'");
+          return _.trim(m.name.getText(), "'\"");
         }
       });
       return {

--- a/test/integration/Emitter.ts
+++ b/test/integration/Emitter.ts
@@ -62,7 +62,7 @@ describe(`Emitter`, () => {
   });
 
   describe(`_emitEnum`, () => {
-    it(`emits GQL type enum for string enum`, () => {
+    it(`emits GQL type enum for string enum with single quotes`, () => {
       const expected =
 `enum Planet {
   CHTHONIAN
@@ -71,6 +71,19 @@ describe(`Emitter`, () => {
 }`;
       const enumNode = loadedTypes['Planet'] as EnumNode;
       const val = emitter._emitEnum(enumNode, 'Planet');
+      expect(val).to.eq(expected);
+    });
+
+    it(`emits GQL type enum for string enum with double quotes`, () => {
+      const expected =
+`enum Seasons {
+  SPRING
+  SUMMER
+  FALL
+  WINTER
+}`;
+      const enumNode = loadedTypes['Seasons'] as EnumNode;
+      const val = emitter._emitEnum(enumNode, 'Seasons');
       expect(val).to.eq(expected);
     });
 

--- a/test/schema.ts
+++ b/test/schema.ts
@@ -30,6 +30,13 @@ export enum Planet {
   PLUTOID      = 'PLUTOID',
 }
 
+export enum Seasons {
+  SPRING   = "SPRING",
+  SUMMER   = "SUMMER",
+  FALL     = "FALL",
+  WINTER   = "WINTER",
+}
+
 export enum Cloud {
   ALTOSTRATUS  = <any>'ALTOSTRATUS',
   CIRROCUMULUS = <any>'CIRROCUMULUS',
@@ -59,6 +66,7 @@ export interface QueryRoot {
   unionOfEnumAndOtherTypes():UnionOfEnumAndOtherTypes[];
   unionOfNonReferenceTypes():UnionOfNonReferenceTypes[];
   planetTypes():Planet;
+  seasonTypes():Seasons;
   cloudTypes():Cloud;
   ordinalTypes():Ordinal;
 }


### PR DESCRIPTION
# Overview

This PR adds support for string enums that are declared using double quotes. This is useful when trying to generate GQL enum definition for an enum that is imported from another module, which uses double quotes.

# Example

```
enum Foo {
  BAR = "BAR",
  BAZ = "BAZ",
}
```

...results in this GQL enum definition:

```
enum Foo {
  BAR
  BAZ
}
```