### PR TITLE
Add support for string literals

### DIFF
--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -70,6 +70,11 @@ export default class Collector {
       result = this._walkArrayTypeNode(<typescript.ArrayTypeNode>node);
     } else if (node.kind === SyntaxKind.UnionType) {
       result = this._walkUnionTypeNode(<typescript.UnionTypeNode>node);
+    } else if (node.kind === SyntaxKind.LiteralType) {
+      result = {
+        type: 'string literal',
+        value: _.trim((<typescript.LiteralTypeNode>node).literal.getText(), "'\""),
+      };
     } else if (node.kind === SyntaxKind.StringKeyword) {
       result = {type: 'string'};
     } else if (node.kind === SyntaxKind.NumberKeyword) {

--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -63,6 +63,14 @@ export default class Emitter {
   }
 
   _emitUnion(node:Types.UnionNode, name:Types.SymbolName):string {
+    if (node.types[0].type === 'string literal') {
+      const nodeValues = node.types.map((type:Types.StringLiteralNode) => type.value);
+      return this._emitEnum({
+        type: 'enum',
+        values: _.uniq(nodeValues),
+      }, this._name(name));
+    }
+
     node.types.map(type => {
       if (type.type !== 'reference') {
         throw new Error(`GraphQL unions require that all types are references. Got a ${type.type}`);

--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -63,7 +63,7 @@ export default class Emitter {
   }
 
   _emitUnion(node:Types.UnionNode, name:Types.SymbolName):string {
-    if (node.types[0].type === 'string literal') {
+    if (_.every(node.types, entry => entry.type === 'string literal')) {
       const nodeValues = node.types.map((type:Types.StringLiteralNode) => type.value);
       return this._emitEnum({
         type: 'enum',

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,11 @@ export interface LiteralObjectNode {
   members:Node[];
 }
 
+export interface StringLiteralNode {
+  type:'string literal';
+  value:string;
+}
+
 export interface StringNode {
   type:'string';
 }
@@ -78,6 +83,7 @@ export type Node =
   EnumNode |
   UnionNode |
   LiteralObjectNode |
+  StringLiteralNode |
   StringNode |
   NumberNode |
   BooleanNode;

--- a/test/integration/Emitter.ts
+++ b/test/integration/Emitter.ts
@@ -36,6 +36,22 @@ describe(`Emitter`, () => {
       expect(val).to.eq(expected);
     });
 
+    it(`emits GQL type enum union for a union type of strings`, () => {
+      const expected =
+`enum QuarkFlavor {
+  UP
+  DOWN
+  CHARM
+  STRANGE
+  TOP
+  BOTTOM
+}`;
+      const aliasNode = loadedTypes['QuarkFlavor'] as AliasNode;
+      const unionNode = aliasNode.target as UnionNode;
+      const val = emitter._emitUnion(unionNode, 'QuarkFlavor');
+      expect(val).to.eq(expected);
+    });
+
     it(`throws error if union combines interfaces with other node types`, () => {
       const aliasNode = loadedTypes['UnionOfInterfaceAndOtherTypes'] as AliasNode;
       const unionNode = aliasNode.target as UnionNode;

--- a/test/schema.ts
+++ b/test/schema.ts
@@ -49,6 +49,8 @@ export enum Ordinal {
   THIRD,
 }
 
+export type QuarkFlavor = "UP" | "DOWN" | "CHARM" | "STRANGE" | "TOP" | "BOTTOM";
+
 export type UnionOfInterfaceTypes = Human | Droid | Starship;
 
 export type UnionOfEnumTypes = Color | Size;
@@ -69,6 +71,7 @@ export interface QueryRoot {
   seasonTypes():Seasons;
   cloudTypes():Cloud;
   ordinalTypes():Ordinal;
+  quarkFlavorTypes():QuarkFlavor;
 }
 
 export interface MutationRoot {


### PR DESCRIPTION
Allow string literals to be converted to enums  Example:
```
 const type Direction = "NORTH" | "EAST" | "SOUTH" | "WEST";
```  
 to become
```
 enum Direction {
    NORTH
    EAST
    SOUTH
    WEST
  }
```
This gives us the ability to have stronger types than enums support and
avoids us having to cast between enums when we want to move from a specific
type to a general type where the specific type is a subset of the general
type.  Example:
```
enum Colors {
  BLACK = 'BLACK',
  RED = 'RED',
  ORANGE = 'ORANGE',
  YELLOW = 'YELLOW',
  GREEN = 'GREEN',
  BLUE = 'BLUE',
  INDIGO = 'INDIGO',
  VIOLET = 'VIOLET',
  WHITE = 'WHITE',
}

enum PrimaryColors {
  RED = 'RED',
  GREEN = 'GREEN',
  BLUE = 'BLUE'
}
```
Requires doing:
```
  const inputColor:PrimaryColors = PrimaryColors.RED;
  const myColor:Colors = Colors[inputColor.toString()];
```
Now you can define PrimaryColors as a string literal union and Typescript
will know the typing.  And we can map them to GraphQL