### PR TITLE
Add support for ‘any’ typed custom Scalars

### DIFF
--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -81,6 +81,8 @@ export default class Collector {
       result = {type: 'number'};
     } else if (node.kind === SyntaxKind.BooleanKeyword) {
       result = {type: 'boolean'};
+    } else if (node.kind === SyntaxKind.AnyKeyword) {
+      result = { type: 'any' };
     } else if (node.kind === SyntaxKind.ModuleDeclaration) {
       // Nada.
     } else if (node.kind === SyntaxKind.VariableDeclaration) {

--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -239,7 +239,7 @@ export default class Emitter {
   }
 
   _isPrimitive(node:Types.Node):boolean {
-    return node.type === 'string' || node.type === 'number' || node.type === 'boolean';
+    return node.type === 'string' || node.type === 'number' || node.type === 'boolean' || node.type === 'any';
   }
 
   _indent(content:string|string[]):string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,10 @@ export interface BooleanNode {
   type:'boolean';
 }
 
+export interface AnyNode {
+  type:'any';
+}
+
 export type Node =
   InterfaceNode |
   MethodNode |
@@ -86,7 +90,8 @@ export type Node =
   StringLiteralNode |
   StringNode |
   NumberNode |
-  BooleanNode;
+  BooleanNode |
+  AnyNode;
 
 export type NamedNode = MethodNode | PropertyNode;
 


### PR DESCRIPTION
Overview
-----
This PR makes a small change which enables a specific workaround to get ts2gql to play nicely with TypeScript. Essentially, this PR makes it so that you can declare a type alias that references `any` and then use that type in your TS code for things that need to be `any`-typed. The resulting GraphQL SDL will create a custom scalar type in its place.

# Before
### Input
```ts
export interface Foo {
  thing: any;
}
```
### Output
❌ **ERROR** ❌
------
# After
### Input
```ts
export type Any = any;

export interface Foo {
  thing: Any;
}
```
### Output
```graphql
scalar Any

type Foo {
  thing: Any
}
```