### PR TITLE
Decorations: docstrings & deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "sinon-chai": "2.13.0",
     "tslint": "5.8.0",
     "tslint-no-unused-expression-chai": "0.0.3",
-    "typescript": "2.6.2"
+    "typescript": "2.8.1"
   },
   "peerDependencies": {
     "typescript": ">=2.0.9"

--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -204,7 +204,7 @@ export default class Collector {
            */
           key = _.trim(m.name.getText(), "'\"");
         }
-        return util.to<types.EnumValueNode>({
+        return <types.EnumValueNode>({
           type: 'enum value',
           key,
           documentation: util.documentationForNode(m),

--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -142,6 +142,7 @@ export default class Collector {
       name: node.name.getText(),
       parameters,
       returns: this._walkNode(node.type!),
+      documentation: util.documentationForNode(node),
     };
   }
 
@@ -150,6 +151,7 @@ export default class Collector {
       type: 'property',
       name: node.name.getText(),
       signature: this._walkNode(node.type!),
+      documentation: util.documentationForNode(node),
     };
   }
 
@@ -169,6 +171,7 @@ export default class Collector {
       const values = node.members.map(m => {
         // If the user provides an initializer, use the value of the initializer
         // as the GQL enum value _unless_ the initializer is a numeric literal.
+        let key:string;
         if (m.initializer && m.initializer.kind !== SyntaxKind.NumericLiteral) {
           /**
            *  Enums with initializers can look like:
@@ -189,7 +192,7 @@ export default class Collector {
            *    }
            */
           const target = _.last(m.initializer.getChildren()) || m.initializer;
-          return _.trim(target.getText(), "'\"");
+          key = _.trim(target.getText(), "'\"");
         } else {
           /**
            *  For Enums without initializers (or with numeric literal initializers), emit the
@@ -199,12 +202,18 @@ export default class Collector {
            *      ACCEPTED,
            *    }
            */
-          return _.trim(m.name.getText(), "'\"");
+          key = _.trim(m.name.getText(), "'\"");
         }
+        return util.to<types.EnumValueNode>({
+          type: 'enum value',
+          key,
+          documentation: util.documentationForNode(m),
+        });
       });
       return {
         type: 'enum',
         values,
+        documentation: util.documentationForNode(node),
       };
     });
   }

--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -1,6 +1,5 @@
 import * as _ from 'lodash';
 
-import * as util from './util';
 import * as Types from './types';
 import { ReferenceNode } from './types';
 
@@ -74,7 +73,7 @@ export default class Emitter {
 
   _emitUnion(node:Types.UnionNode, name:Types.SymbolName):string {
     if (_.every(node.types, entry => entry.type === 'string literal')) {
-      const nodeValues = node.types.map((type:Types.StringLiteralNode) => util.to<Types.EnumValueNode>({
+      const nodeValues = node.types.map((type:Types.StringLiteralNode) => <Types.EnumValueNode>({
         type: 'enum value',
         key: type.value,
       }));
@@ -139,7 +138,7 @@ export default class Emitter {
     }
 
     const properties = _.map(members, (member) => {
-      let result:string = '';
+      let result = '';
       const description = this._getDescription(member);
       if (description) {
         result += this._blockString(description);
@@ -304,9 +303,7 @@ export default class Emitter {
   }
 
   _indent(content:string|string[]):string {
-    if (!_.isArray(content)) {
-      content = [content];
-    }
+    content = _.castArray(content);
     content = _.flatMap(content, (s:string) => s.split('\n'));
     return content.map(s => `  ${s}`).join('\n');
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,9 @@ export function load(schemaRootPath:string, rootNodeNames:string[]):types.TypeMa
   schemaRootPath = path.resolve(schemaRootPath);
   const program = typescript.createProgram([schemaRootPath], {});
   const schemaRoot = program.getSourceFile(schemaRootPath);
+  if (!schemaRoot) {
+    throw new Error(`getSourceFile(${JSON.stringify(schemaRootPath)}) failed`);
+  }
 
   const interfaces:{[key:string]:typescript.InterfaceDeclaration} = {};
   typescript.forEachChild(schemaRoot, (node) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,12 @@ export interface AliasNode extends ComplexNode {
 
 export interface EnumNode extends ComplexNode {
   type:'enum';
-  values:string[];
+  values:EnumValueNode[];
+}
+
+export interface EnumValueNode extends ComplexNode {
+  type:'enum value'
+  key: string;
 }
 
 export interface UnionNode extends ComplexNode {

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,7 @@ export type Node =
   PropertyNode |
   AliasNode |
   EnumNode |
+  EnumValueNode |
   UnionNode |
   LiteralObjectNode |
   StringLiteralNode |

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,8 +47,8 @@ export interface EnumNode extends ComplexNode {
 }
 
 export interface EnumValueNode extends ComplexNode {
-  type:'enum value'
-  key: string;
+  type:'enum value';
+  key:string;
 }
 
 export interface UnionNode extends ComplexNode {

--- a/src/util.ts
+++ b/src/util.ts
@@ -13,9 +13,3 @@ export function documentationForNode(node:typescript.Node, source?:string):doctr
 
   return doctrine.parse(comment, {unwrap: true});
 }
-
-// Typed identity functino.
-// Useful for enforcing a type on a literal without risking an unsafe cast.
-export function to<T>(x: T): T {
-  return x;
-}

--- a/src/util.ts
+++ b/src/util.ts
@@ -13,3 +13,9 @@ export function documentationForNode(node:typescript.Node, source?:string):doctr
 
   return doctrine.parse(comment, {unwrap: true});
 }
+
+// Typed identity functino.
+// Useful for enforcing a type on a literal without risking an unsafe cast.
+export function to<T>(x: T): T {
+  return x;
+}

--- a/test/integration/Emitter.ts
+++ b/test/integration/Emitter.ts
@@ -151,8 +151,6 @@ describe(`Emitter`, () => {
 }`;
       const node = loadedTypes['HasDeprecatedFields'] as InterfaceNode;
       const val = emitter._emitInterface(node, 'HasDeprecatedFields');
-      console.log(val);
-      console.log(expected);
       expect(val).to.eq(expected);
     });
 

--- a/test/integration/Emitter.ts
+++ b/test/integration/Emitter.ts
@@ -137,34 +137,36 @@ describe(`Emitter`, () => {
       expect(val).to.eq(expected);
     });
 
-    it(`emits deprecated directives for TypeScript methods`, () => {
+    it(`emits decorated fields`, () => {
       const expected =
-`type HasDeprecatedMethod {
-  doNotUse: String @deprecated
+`type HasDeprecatedFields {
+  """
+  A bad method.
+  """
+  badMethod: String @deprecated
+  """
+  And a bad property.
+  """
+  badProperty: String @deprecated(reason: "Avoid this.")
 }`;
-      const node = loadedTypes['HasDeprecatedMethod'] as InterfaceNode;
-      const val = emitter._emitInterface(node, 'HasDeprecatedMethod');
+      const node = loadedTypes['HasDeprecatedFields'] as InterfaceNode;
+      const val = emitter._emitInterface(node, 'HasDeprecatedFields');
+      console.log(val);
+      console.log(expected);
       expect(val).to.eq(expected);
     });
 
-    it(`emits deprecated directives for TypeScript properties`, () => {
+    it(`emits decorated enums and enum values`, () => {
       const expected =
-`type HasDeprecatedProperty {
-  doNotUse: String @deprecated(reason: "Avoid This.")
-}`;
-      const node = loadedTypes['HasDeprecatedProperty'] as InterfaceNode;
-      const val = emitter._emitInterface(node, 'HasDeprecatedProperty');
-      expect(val).to.eq(expected);
-    });
-
-    it(`emits deprecated directives for enum values`, () => {
-      const expected =
-`enum HasDeprecatedEnumValue @deprecated {
-  USE_ME
+`"""
+Both this enum and one of its values are deprecated.
+"""
+enum HasDeprecatedEnumValue @deprecated {
+  "This is what you want." USE_ME
   NOT_ME @deprecated
 }`;
       const node = loadedTypes['HasDeprecatedEnumValue'] as EnumNode;
-      const val = emitter._emitEnum(node, 'HasDeprecatedEnumValue');
+      const val = emitter._emitTopLevelNode(node, 'HasDeprecatedEnumValue');
       expect(val).to.eq(expected);
     });
 

--- a/test/integration/Emitter.ts
+++ b/test/integration/Emitter.ts
@@ -1,7 +1,7 @@
 import Emitter from '../../src/Emitter';
 import * as types from '../../src/types';
 import * as ts2gql from '../../src/index';
-import { UnionNode, AliasNode, EnumNode } from '../../src/types';
+import { UnionNode, AliasNode, EnumNode, InterfaceNode } from '../../src/types';
 
 describe(`Emitter`, () => {
 
@@ -126,5 +126,47 @@ describe(`Emitter`, () => {
       const val = emitter._emitEnum(enumNode, 'Ordinal');
       expect(val).to.eq(expected);
     });
+
+    it(`emits deprecated directives for TypeScript interfaces`, () => {
+      const expected =
+`type DeprecatedNode @deprecated {
+  field: String
+}`;
+      const node = loadedTypes['DeprecatedNode'] as InterfaceNode;
+      const val = emitter._emitInterface(node, 'DeprecatedNode');
+      expect(val).to.eq(expected);
+    });
+
+    it(`emits deprecated directives for TypeScript methods`, () => {
+      const expected =
+`type HasDeprecatedMethod {
+  doNotUse: String @deprecated
+}`;
+      const node = loadedTypes['HasDeprecatedMethod'] as InterfaceNode;
+      const val = emitter._emitInterface(node, 'HasDeprecatedMethod');
+      expect(val).to.eq(expected);
+    });
+
+    it(`emits deprecated directives for TypeScript properties`, () => {
+      const expected =
+`type HasDeprecatedProperty {
+  doNotUse: String @deprecated(reason: "Avoid This.")
+}`;
+      const node = loadedTypes['HasDeprecatedProperty'] as InterfaceNode;
+      const val = emitter._emitInterface(node, 'HasDeprecatedProperty');
+      expect(val).to.eq(expected);
+    });
+
+    it(`emits deprecated directives for enum values`, () => {
+      const expected =
+`enum HasDeprecatedEnumValue @deprecated {
+  USE_ME
+  NOT_ME @deprecated
+}`;
+      const node = loadedTypes['HasDeprecatedEnumValue'] as EnumNode;
+      const val = emitter._emitEnum(node, 'HasDeprecatedEnumValue');
+      expect(val).to.eq(expected);
+    });
+
   });
 });

--- a/test/schema.ts
+++ b/test/schema.ts
@@ -61,6 +61,28 @@ export type UnionOfEnumAndOtherTypes = Color | UnionOfInterfaceTypes;
 
 export type UnionOfNonReferenceTypes = boolean | string;
 
+/** @deprecated */
+export interface DeprecatedNode {
+  field():string;
+}
+
+export interface HasDeprecatedMethod {
+  /** @deprecated */
+  doNotUse():string;
+}
+
+export interface HasDeprecatedProperty {
+  /** @deprecated Avoid This. */
+  doNotUse:string;
+}
+
+/** @deprecated */
+export enum HasDeprecatedEnumValue {
+  USE_ME,
+  /** @deprecated */
+  NOT_ME,
+}
+
 export interface QueryRoot {
   unionOfInterfaceTypes():UnionOfInterfaceTypes[];
   unionOfEnumTypes():UnionOfEnumTypes[];
@@ -72,6 +94,10 @@ export interface QueryRoot {
   cloudTypes():Cloud;
   ordinalTypes():Ordinal;
   quarkFlavorTypes():QuarkFlavor;
+  deprecatedNode():DeprecatedNode;
+  hasDeprecatedMethod():HasDeprecatedMethod;
+  hasDeprecatedProperty():HasDeprecatedProperty;
+  hasDeprecatedEnumValue():HasDeprecatedEnumValue;
 }
 
 export interface MutationRoot {

--- a/test/schema.ts
+++ b/test/schema.ts
@@ -66,18 +66,25 @@ export interface DeprecatedNode {
   field():string;
 }
 
-export interface HasDeprecatedMethod {
-  /** @deprecated */
-  doNotUse():string;
+export interface HasDeprecatedFields {
+  /**
+   * A bad method.
+   * @deprecated
+   */
+  badMethod():string;
+  /**
+   * And a bad property.
+   * @deprecated Avoid this.
+   */
+  badProperty:string;
 }
 
-export interface HasDeprecatedProperty {
-  /** @deprecated Avoid This. */
-  doNotUse:string;
-}
-
-/** @deprecated */
+/**
+ * Both this enum and one of its values are deprecated.
+ * @deprecated
+ */
 export enum HasDeprecatedEnumValue {
+  /** This is what you want. */
   USE_ME,
   /** @deprecated */
   NOT_ME,
@@ -95,8 +102,7 @@ export interface QueryRoot {
   ordinalTypes():Ordinal;
   quarkFlavorTypes():QuarkFlavor;
   deprecatedNode():DeprecatedNode;
-  hasDeprecatedMethod():HasDeprecatedMethod;
-  hasDeprecatedProperty():HasDeprecatedProperty;
+  hasDeprecatedFields():HasDeprecatedFields;
   hasDeprecatedEnumValue():HasDeprecatedEnumValue;
 }
 


### PR DESCRIPTION
This adds initial supports for two types of decorations from jsdoc comments:

1) Documentation strings.
2) deprecated annotations.

See the tests for examples of this in action.