### PR TITLE
Remove default field "scalar Date" from TypeMap

### DIFF
--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -66,6 +66,9 @@ export default class Collector {
       result = this._walkEnumDeclaration(<typescript.EnumDeclaration>node);
     } else if (node.kind === SyntaxKind.TypeLiteral) {
       result = this._walkTypeLiteralNode(<typescript.TypeLiteralNode>node);
+    } else if (node.kind === SyntaxKind.ParenthesizedType) {
+      const parenthesizedNode = node as typescript.ParenthesizedTypeNode
+      result = this._walkNode(parenthesizedNode.type)
     } else if (node.kind === SyntaxKind.ArrayType) {
       result = this._walkArrayTypeNode(<typescript.ArrayTypeNode>node);
     } else if (node.kind === SyntaxKind.UnionType) {
@@ -76,13 +79,17 @@ export default class Collector {
         value: _.trim((<typescript.LiteralTypeNode>node).literal.getText(), "'\""),
       };
     } else if (node.kind === SyntaxKind.StringKeyword) {
-      result = {type: 'string'};
+      result = {type: 'notnull', node: {type: 'string'}};
     } else if (node.kind === SyntaxKind.NumberKeyword) {
-      result = {type: 'number'};
+      result = {type: 'notnull', node: {type: 'number'}};
     } else if (node.kind === SyntaxKind.BooleanKeyword) {
-      result = {type: 'boolean'};
+      result = {type: 'notnull', node: {type: 'boolean'}};
     } else if (node.kind === SyntaxKind.AnyKeyword) {
       result = { type: 'any' };
+    } else if (node.kind === SyntaxKind.NullKeyword) {
+      result = {type: 'null'};
+    } else if (node.kind === SyntaxKind.UndefinedKeyword) {
+      result = {type: 'undefined'};
     } else if (node.kind === SyntaxKind.ModuleDeclaration) {
       // Nada.
     } else if (node.kind === SyntaxKind.VariableDeclaration) {
@@ -146,15 +153,16 @@ export default class Collector {
   }
 
   _walkPropertySignature(node:typescript.PropertySignature):types.Node {
+    const signature = this._walkNode(node.type!)
     return {
       type: 'property',
       name: node.name.getText(),
-      signature: this._walkNode(node.type!),
+      signature: (node.questionToken && signature.type === 'notnull' ) ? signature.node : signature,
     };
   }
 
   _walkTypeReferenceNode(node:typescript.TypeReferenceNode):types.Node {
-    return this._referenceForSymbol(this._symbolForNode(node.typeName));
+    return { type: 'notnull', node: this._referenceForSymbol(this._symbolForNode(node.typeName)) };
   }
 
   _walkTypeAliasDeclaration(node:typescript.TypeAliasDeclaration):types.Node {
@@ -218,8 +226,11 @@ export default class Collector {
 
   _walkArrayTypeNode(node:typescript.ArrayTypeNode):types.Node {
     return {
-      type: 'array',
-      elements: [this._walkNode(node.elementType)],
+      type: 'notnull',
+      node: {
+        type: 'array',
+        elements: [this._walkNode(node.elementType)]
+      }
     };
   }
 

--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -12,9 +12,7 @@ const TypeFlags = typescript.TypeFlags;
  * referenced types.
  */
 export default class Collector {
-  types:types.TypeMap = {
-    Date: {type: 'alias', target: {type: 'string'}},
-  };
+  types:types.TypeMap = {};
   private checker:typescript.TypeChecker;
   private nodeMap:Map<typescript.Node, types.Node> = new Map();
 

--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -34,15 +34,21 @@ export default class Emitter {
   // Preprocessing
 
   _preprocessNode(node:Types.Node, name:Types.SymbolName):boolean {
+    const specialTags = ['ID', 'Int', 'Float'];
+
     if (node.type === 'alias' && node.target.type === 'reference') {
       const referencedNode = this.types[node.target.target];
       if (this._isPrimitive(referencedNode) || referencedNode.type === 'enum') {
         this.renames[name] = node.target.target;
         return true;
       }
-    } else if (node.type === 'alias' && this._hasDocTag(node, 'ID')) {
-      this.renames[name] = 'ID';
-      return true;
+    } else if (node.type === 'alias') {
+      for (const tag of specialTags) {
+        if (this._hasDocTag(node, tag)) {
+          this.renames[name] = tag;
+          return true;
+        }
+      }
     }
 
     return false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,19 @@ export interface AnyNode {
   type:'any';
 }
 
+export interface NullNode {
+  type:'null';
+}
+
+export interface UndefinedNode {
+  type:'undefined';
+}
+
+export interface NotNullNode {
+  type:'notnull';
+  node:Node;
+}
+
 export type Node =
   InterfaceNode |
   MethodNode |
@@ -91,6 +104,9 @@ export type Node =
   StringNode |
   NumberNode |
   BooleanNode |
+  NullNode |
+  UndefinedNode |
+  NotNullNode |
   AnyNode;
 
 export type NamedNode = MethodNode | PropertyNode;


### PR DESCRIPTION
This PR fixes the default adding of ` scalar Date` to every schema transpiled with ts2gql.

Have no idea why the original repo had this built in