### PR TITLE
Remove second underscore from placeholder

### DIFF
--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -132,7 +132,7 @@ export default class Emitter {
     if (!members.length) {
       members.push({
         type: 'property',
-        name: '__placeholder',
+        name: '_placeholder',
         signature: {type: 'boolean'},
       });
     }


### PR DESCRIPTION
`Name \"__placeholder\" must not begin with \"__\", which is reserved by GraphQL introspection.`

This is to fix that issue. Empty resolvers are weird but this will re-enable them.