### PR TITLE
Revert "Decorations: docstrings & deprecated"

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "sinon-chai": "2.13.0",
     "tslint": "5.8.0",
     "tslint-no-unused-expression-chai": "0.0.3",
-    "typescript": "2.8.1"
+    "typescript": "2.6.2"
   },
   "peerDependencies": {
     "typescript": ">=2.0.9"

--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -142,7 +142,6 @@ export default class Collector {
       name: node.name.getText(),
       parameters,
       returns: this._walkNode(node.type!),
-      documentation: util.documentationForNode(node),
     };
   }
 
@@ -151,7 +150,6 @@ export default class Collector {
       type: 'property',
       name: node.name.getText(),
       signature: this._walkNode(node.type!),
-      documentation: util.documentationForNode(node),
     };
   }
 
@@ -171,7 +169,6 @@ export default class Collector {
       const values = node.members.map(m => {
         // If the user provides an initializer, use the value of the initializer
         // as the GQL enum value _unless_ the initializer is a numeric literal.
-        let key:string;
         if (m.initializer && m.initializer.kind !== SyntaxKind.NumericLiteral) {
           /**
            *  Enums with initializers can look like:
@@ -192,7 +189,7 @@ export default class Collector {
            *    }
            */
           const target = _.last(m.initializer.getChildren()) || m.initializer;
-          key = _.trim(target.getText(), "'\"");
+          return _.trim(target.getText(), "'\"");
         } else {
           /**
            *  For Enums without initializers (or with numeric literal initializers), emit the
@@ -202,18 +199,12 @@ export default class Collector {
            *      ACCEPTED,
            *    }
            */
-          key = _.trim(m.name.getText(), "'\"");
+          return _.trim(m.name.getText(), "'\"");
         }
-        return <types.EnumValueNode>({
-          type: 'enum value',
-          key,
-          documentation: util.documentationForNode(m),
-        });
       });
       return {
         type: 'enum',
         values,
-        documentation: util.documentationForNode(node),
       };
     });
   }

--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -18,26 +18,17 @@ export default class Emitter {
   }
 
   emitTopLevelNode(node:Types.Node, name:Types.SymbolName, stream:NodeJS.WritableStream) {
-    const content = this._emitTopLevelNode(node, name);
-    stream.write(`${content}\n\n`);
-  }
-
-  _emitTopLevelNode(node:Types.Node, name:Types.SymbolName) {
-    let content = '';
-    const description = this._getDescription(node);
-    if (description) {
-      content += this._blockString(description) + '\n';
-    }
+    let content;
     if (node.type === 'alias') {
-      content += this._emitAlias(node, name);
+      content = this._emitAlias(node, name);
     } else if (node.type === 'interface') {
-      content += this._emitInterface(node, name);
+      content = this._emitInterface(node, name);
     } else if (node.type === 'enum') {
-      content += this._emitEnum(node, name);
+      content = this._emitEnum(node, name);
     } else {
       throw new Error(`Don't know how to emit ${node.type} as a top level node`);
     }
-    return content;
+    stream.write(`${content}\n\n`);
   }
 
   // Preprocessing
@@ -49,7 +40,7 @@ export default class Emitter {
         this.renames[name] = node.target.target;
         return true;
       }
-    } else if (node.type === 'alias' && this._hasDocTag(node, 'graphql', 'ID')) {
+    } else if (node.type === 'alias' && this._hasDocTag(node, 'ID')) {
       this.renames[name] = 'ID';
       return true;
     }
@@ -73,13 +64,10 @@ export default class Emitter {
 
   _emitUnion(node:Types.UnionNode, name:Types.SymbolName):string {
     if (_.every(node.types, entry => entry.type === 'string literal')) {
-      const nodeValues = node.types.map((type:Types.StringLiteralNode) => <Types.EnumValueNode>({
-        type: 'enum value',
-        key: type.value,
-      }));
+      const nodeValues = node.types.map((type:Types.StringLiteralNode) => type.value);
       return this._emitEnum({
         type: 'enum',
-        values: _.uniqBy(nodeValues, v => v.key),
+        values: _.uniq(nodeValues),
       }, this._name(name));
     }
 
@@ -138,12 +126,6 @@ export default class Emitter {
     }
 
     const properties = _.map(members, (member) => {
-      let result = '';
-      const description = this._getDescription(member);
-      if (description) {
-        result += this._blockString(description);
-        result += '\n';
-      }
       if (member.type === 'method') {
         let parameters = '';
         if (_.size(member.parameters) > 1) {
@@ -156,49 +138,35 @@ export default class Emitter {
           parameters = `(${this._emitExpression(argType)})`;
         }
         const returnType = this._emitExpression(member.returns);
-        result += `${this._name(member.name)}${parameters}: ${returnType}`;
+        return `${this._name(member.name)}${parameters}: ${returnType}`;
       } else if (member.type === 'property') {
-        result += `${this._name(member.name)}: ${this._emitExpression(member.signature)}`;
+        return `${this._name(member.name)}: ${this._emitExpression(member.signature)}`;
       } else {
         throw new Error(`Can't serialize ${member.type} as a property of an interface`);
       }
-      result += this._emitDirectives(member);
-      return result;
     });
 
-    if (this._getDocTag(node, 'graphql', 'schema')) {
+    if (this._getDocTag(node, 'schema')) {
       return `schema {\n${this._indent(properties)}\n}`;
-    } else if (this._getDocTag(node, 'graphql', 'input')) {
-      return `input ${this._name(name)}${this._emitDirectives(node)} {\n${this._indent(properties)}\n}`;
+    } else if (this._getDocTag(node, 'input')) {
+      return `input ${this._name(name)} {\n${this._indent(properties)}\n}`;
     }
 
     if (node.concrete) {
-      return `type ${this._name(name)}${this._emitDirectives(node)} {\n${this._indent(properties)}\n}`;
+      return `type ${this._name(name)} {\n${this._indent(properties)}\n}`;
     }
 
-    let output = `interface ${this._name(name)}${this._emitDirectives(node)} {\n${this._indent(properties)}\n}`;
-    const fragmentDeclaration = this._getDocTag(node, 'graphql', 'fragment');
+    let result = `interface ${this._name(name)} {\n${this._indent(properties)}\n}`;
+    const fragmentDeclaration = this._getDocTag(node, 'fragment');
     if (fragmentDeclaration) {
-      output = `${output}\n\n${fragmentDeclaration} {\n${this._indent(members.map((m:any) => m.name))}\n}`;
+      result = `${result}\n\n${fragmentDeclaration} {\n${this._indent(members.map((m:any) => m.name))}\n}`;
     }
-    return output;
+
+    return result;
   }
 
   _emitEnum(node:Types.EnumNode, name:Types.SymbolName):string {
-    const values = node.values.map(v => this._emitEnumValue(v));
-    return `enum ${this._name(name)}${this._emitDirectives(node)} {\n${this._indent(values)}\n}`;
-  }
-
-  _emitEnumValue(node:Types.EnumValueNode):string {
-    let result = '';
-    const description = this._getDescription(node);
-    if (description) {
-      result += this._stringValue(description);
-      result += ' ';
-    }
-    result += node.key;
-    result += this._emitDirectives(node);
-    return result;
+    return `enum ${this._name(name)} {\n${this._indent(node.values)}\n}`;
   }
 
   _emitExpression = (node:Types.Node):string => {
@@ -263,21 +231,6 @@ export default class Emitter {
     return members as Types.PropertyNode[];
   }
 
-  // Directives
-
-  _emitDirectives(node:Types.ComplexNode):string {
-    let directives = '';
-    const deprecated = this._getDocTag(node, 'deprecated');
-    if (deprecated !== null) {
-      directives += ' @deprecated';
-      const reason = deprecated.trim();
-      if (reason !== '') {
-        directives += `(reason: ${this._stringValue(reason)})`;
-      }
-    }
-    return directives;
-  }
-
   // Utility
 
   _name = (name:Types.SymbolName):string => {
@@ -285,26 +238,12 @@ export default class Emitter {
     return name.replace(/\W/g, '_');
   }
 
-  _stringValue(value:string):string {
-    // This is close enough for now.
-    // TODO: Escape properly as per https://facebook.github.io/graphql/draft/#sec-String-Value
-    return JSON.stringify(value);
-  }
-
-  _blockString(value:string):string {
-    // TODO: Properly encode "block strings".
-    // See: https://facebook.github.io/graphql/draft/#sec-String-Value
-    const s = this._stringValue(value);
-    return '"""\n' + s.substr(1, s.length - 2) + '\n"""';
-  }
-
   _isPrimitive(node:Types.Node):boolean {
     return node.type === 'string' || node.type === 'number' || node.type === 'boolean' || node.type === 'any';
   }
 
   _indent(content:string|string[]):string {
-    content = _.castArray(content);
-    content = _.flatMap(content, (s:string) => s.split('\n'));
+    if (!_.isArray(content)) content = content.split('\n');
     return content.map(s => `  ${s}`).join('\n');
   }
 
@@ -317,22 +256,15 @@ export default class Emitter {
     return _.uniq(interfaces);
   }
 
-  _hasDocTag(node:Types.ComplexNode, title:string, prefix = ''):boolean {
-    return this._getDocTag(node, title, prefix) !== null;
+  _hasDocTag(node:Types.ComplexNode, prefix:string):boolean {
+    return !!this._getDocTag(node, prefix);
   }
 
-  _getDescription(node:Types.Node):string|null {
-    const complexNode = node as Types.ComplexNode;
-    if (!complexNode.documentation) return null;
-    return complexNode.documentation.description;
-  }
-
-  _getDocTag(node:Types.ComplexNode, title:string, prefix = ''):string|null {
+  _getDocTag(node:Types.ComplexNode, prefix:string):string|null {
     if (!node.documentation) return null;
     for (const tag of node.documentation.tags) {
-      if (tag.title !== title) continue;
-      const description = tag.description || '';
-      if (description.startsWith(prefix)) return description;
+      if (tag.title !== 'graphql') continue;
+      if (tag.description.startsWith(prefix)) return tag.description;
     }
     return null;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,6 @@ export function load(schemaRootPath:string, rootNodeNames:string[]):types.TypeMa
   schemaRootPath = path.resolve(schemaRootPath);
   const program = typescript.createProgram([schemaRootPath], {});
   const schemaRoot = program.getSourceFile(schemaRootPath);
-  if (!schemaRoot) {
-    throw new Error(`getSourceFile(${JSON.stringify(schemaRootPath)}) failed`);
-  }
 
   const interfaces:{[key:string]:typescript.InterfaceDeclaration} = {};
   typescript.forEachChild(schemaRoot, (node) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,12 +43,7 @@ export interface AliasNode extends ComplexNode {
 
 export interface EnumNode extends ComplexNode {
   type:'enum';
-  values:EnumValueNode[];
-}
-
-export interface EnumValueNode extends ComplexNode {
-  type:'enum value';
-  key:string;
+  values:string[];
 }
 
 export interface UnionNode extends ComplexNode {
@@ -90,7 +85,6 @@ export type Node =
   PropertyNode |
   AliasNode |
   EnumNode |
-  EnumValueNode |
   UnionNode |
   LiteralObjectNode |
   StringLiteralNode |

--- a/test/integration/Emitter.ts
+++ b/test/integration/Emitter.ts
@@ -1,7 +1,7 @@
 import Emitter from '../../src/Emitter';
 import * as types from '../../src/types';
 import * as ts2gql from '../../src/index';
-import { UnionNode, AliasNode, EnumNode, InterfaceNode } from '../../src/types';
+import { UnionNode, AliasNode, EnumNode } from '../../src/types';
 
 describe(`Emitter`, () => {
 
@@ -126,47 +126,5 @@ describe(`Emitter`, () => {
       const val = emitter._emitEnum(enumNode, 'Ordinal');
       expect(val).to.eq(expected);
     });
-
-    it(`emits deprecated directives for TypeScript interfaces`, () => {
-      const expected =
-`type DeprecatedNode @deprecated {
-  field: String
-}`;
-      const node = loadedTypes['DeprecatedNode'] as InterfaceNode;
-      const val = emitter._emitInterface(node, 'DeprecatedNode');
-      expect(val).to.eq(expected);
-    });
-
-    it(`emits decorated fields`, () => {
-      const expected =
-`type HasDeprecatedFields {
-  """
-  A bad method.
-  """
-  badMethod: String @deprecated
-  """
-  And a bad property.
-  """
-  badProperty: String @deprecated(reason: "Avoid this.")
-}`;
-      const node = loadedTypes['HasDeprecatedFields'] as InterfaceNode;
-      const val = emitter._emitInterface(node, 'HasDeprecatedFields');
-      expect(val).to.eq(expected);
-    });
-
-    it(`emits decorated enums and enum values`, () => {
-      const expected =
-`"""
-Both this enum and one of its values are deprecated.
-"""
-enum HasDeprecatedEnumValue @deprecated {
-  "This is what you want." USE_ME
-  NOT_ME @deprecated
-}`;
-      const node = loadedTypes['HasDeprecatedEnumValue'] as EnumNode;
-      const val = emitter._emitTopLevelNode(node, 'HasDeprecatedEnumValue');
-      expect(val).to.eq(expected);
-    });
-
   });
 });

--- a/test/schema.ts
+++ b/test/schema.ts
@@ -61,35 +61,6 @@ export type UnionOfEnumAndOtherTypes = Color | UnionOfInterfaceTypes;
 
 export type UnionOfNonReferenceTypes = boolean | string;
 
-/** @deprecated */
-export interface DeprecatedNode {
-  field():string;
-}
-
-export interface HasDeprecatedFields {
-  /**
-   * A bad method.
-   * @deprecated
-   */
-  badMethod():string;
-  /**
-   * And a bad property.
-   * @deprecated Avoid this.
-   */
-  badProperty:string;
-}
-
-/**
- * Both this enum and one of its values are deprecated.
- * @deprecated
- */
-export enum HasDeprecatedEnumValue {
-  /** This is what you want. */
-  USE_ME,
-  /** @deprecated */
-  NOT_ME,
-}
-
 export interface QueryRoot {
   unionOfInterfaceTypes():UnionOfInterfaceTypes[];
   unionOfEnumTypes():UnionOfEnumTypes[];
@@ -101,9 +72,6 @@ export interface QueryRoot {
   cloudTypes():Cloud;
   ordinalTypes():Ordinal;
   quarkFlavorTypes():QuarkFlavor;
-  deprecatedNode():DeprecatedNode;
-  hasDeprecatedFields():HasDeprecatedFields;
-  hasDeprecatedEnumValue():HasDeprecatedEnumValue;
 }
 
 export interface MutationRoot {


### PR DESCRIPTION
Reverts convoyinc/ts2gql#24

I need to get a ts2gql fix in to get other code in. This appears to be unused in our code base:
https://sourcegraph.convoy.com/search?q=%222.0.89%22

...and looks very suspicious for errors I see when I upgrade to get my ts2gql changes in.

I'll work with @brandonbloom when he gets back to revert the revert, but for now I just want to unblock myself.