### PR TITLE
Correct SourceFile resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts2gql",
-  "version": "2.0.1",
+  "version": "2.0.94",
   "description": "Converts a TypeScript type hierarchy into GraphQL's IDL.",
   "homepage": "https://github.com/convoyinc/ts2gql",
   "bugs": "https://github.com/convoyinc/ts2gql/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts2gql",
-  "version": "2.0.94",
+  "version": "2.0.1",
   "description": "Converts a TypeScript type hierarchy into GraphQL's IDL.",
   "homepage": "https://github.com/convoyinc/ts2gql",
   "bugs": "https://github.com/convoyinc/ts2gql/issues",

--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -292,7 +292,12 @@ export default class Collector {
       parts.unshift(this.checker.symbolToString(symbol));
       symbol = symbol['parent'];
       // Don't include raw module names.
-      if (symbol && symbol.flags === typescript.SymbolFlags.ValueModule) break;
+      const node = symbol && symbol.declarations ? symbol.declarations[0] : undefined;
+
+      // https://github.com/microsoft/TypeScript/blob/922186834fd54d7a095c4995528f04f6e5dae41a/src/compiler/types.ts
+      if (node && node.kind === typescript.SyntaxKind.SourceFile) {
+        break;
+      }
     }
 
     return parts.join('.');


### PR DESCRIPTION
We were using the Symbol, which apparently has some quirks. This will now use the node instead, and look for the correct SyntaxType.

Old schema (includes a few local changes) - 
https://docs.google.com/document/d/1Rfh1YKMvKdwD5v_FPjUPfJ1uziBkybCJnHBXVPK_5-M/edit?usp=sharing

New schema - 
https://docs.google.com/document/d/1ZwgfsA9YyTlesjtM0AJ9q2_IxHaed1nLDB6dlTJR74o/edit?usp=sharing

Note that there ARE some other types that are going to need to be changed.