### PR TITLE
Add ts2gql support for the @key federation decorator

### DIFF
--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -154,10 +154,9 @@ export default class Emitter {
 
     if (node.concrete) {
       // If tagged with a "key" graphql tag, add the @key annotation for federation
-      let federationDecorator = '';
-      this._getDocTags(node, 'key').forEach(tag => {
-        federationDecorator += `@key(fields: "${tag.substr(4)}") `;
-      });
+      const federationDecorator = this._getDocTags(node, 'key')
+        .map(tag => `@key(fields: "${tag.substring(4)}") `)
+        .join('');
       return `type ${this._name(name)} ${federationDecorator}{\n${this._indent(properties)}\n}`;
     }
 
@@ -275,8 +274,8 @@ export default class Emitter {
   }
 
   // Returns ALL matching tags from the given node.
-  _getDocTags(node:Types.ComplexNode, prefix:string):String[] {
-    const matchingTags:String[] = [];
+  _getDocTags(node:Types.ComplexNode, prefix:string):string[] {
+    const matchingTags:string[] = [];
     if (!node.documentation) return matchingTags;
     for (const tag of node.documentation.tags) {
       if (tag.title !== 'graphql') continue;

--- a/test/integration/Emitter.ts
+++ b/test/integration/Emitter.ts
@@ -127,4 +127,52 @@ describe(`Emitter`, () => {
       expect(val).to.eq(expected);
     });
   });
+
+  describe(`federation decoration`, () => {
+    it(`basic type generation`, () => {
+      const expected =
+`type Starship {
+  length: Float
+  name: String
+}`;
+      const node = loadedTypes['Starship'] as types.InterfaceNode;
+      const val = emitter._emitInterface(node, 'Starship');
+      expect(val).to.eq(expected);
+    });
+  });
+
+  it(`basic key decoration`, () => {
+    const expected =
+`type StarshipFederated @key(fields: "name") {
+  length: Float
+  name: String
+}`;
+    const node = loadedTypes['StarshipFederated'] as types.InterfaceNode;
+    const val = emitter._emitInterface(node, 'StarshipFederated');
+    expect(val).to.eq(expected);
+  });
+
+  it(`compound key decoration`, () => {
+    const expected =
+`type StarshipFederatedCompoundKey @key(fields: "name id") {
+  id: String
+  length: Float
+  name: String
+}`;
+    const node = loadedTypes['StarshipFederatedCompoundKey'] as types.InterfaceNode;
+    const val = emitter._emitInterface(node, 'StarshipFederatedCompoundKey');
+    expect(val).to.eq(expected);
+  });
+
+  it(`multiple keys decoration`, () => {
+    const expected =
+`type StarshipFederatedMultipleKeys @key(fields: "name") @key(fields: "id") {
+  id: String
+  length: Float
+  name: String
+}`;
+    const node = loadedTypes['StarshipFederatedMultipleKeys'] as types.InterfaceNode;
+    const val = emitter._emitInterface(node, 'StarshipFederatedMultipleKeys');
+    expect(val).to.eq(expected);
+  });
 });

--- a/test/schema.ts
+++ b/test/schema.ts
@@ -13,6 +13,29 @@ export interface Starship {
   length:number;
 }
 
+/** @graphql key name */
+export interface StarshipFederated {
+  name:string;
+  length:number;
+}
+
+/** @graphql key name id */
+export interface StarshipFederatedCompoundKey {
+  name:string;
+  id:string;
+  length:number;
+}
+
+/**
+ * @graphql key name
+ * @graphql key id
+ */
+export interface StarshipFederatedMultipleKeys {
+  name:string;
+  id:string;
+  length:number;
+}
+
 export enum Color {
   'Red',
   'Yellow',
@@ -72,6 +95,9 @@ export interface QueryRoot {
   cloudTypes():Cloud;
   ordinalTypes():Ordinal;
   quarkFlavorTypes():QuarkFlavor;
+  starshipFederated():StarshipFederated;
+  starshipFederatedCompound():StarshipFederatedCompoundKey;
+  starshipFederatedMultiple():StarshipFederatedMultipleKeys;
 }
 
 export interface MutationRoot {


### PR DESCRIPTION
We will likely want to enable federation to some Shipotle types before we get rid of ts2gql, so this adds the ability to specify @key federation decorators using tags, unblocking that option.

Tested with unit tests.