### PR TITLE
Add support for cost decorator on fields and type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts2gql",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Converts a TypeScript type hierarchy into GraphQL's IDL.",
   "homepage": "https://github.com/convoyinc/ts2gql",
   "bugs": "https://github.com/convoyinc/ts2gql/issues",

--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -140,6 +140,7 @@ export default class Collector {
     return {
       type: 'method',
       name: node.name.getText(),
+      documentation: util.documentationForNode(node),
       parameters,
       returns: this._walkNode(node.type!),
     };
@@ -149,6 +150,7 @@ export default class Collector {
     return {
       type: 'property',
       name: node.name.getText(),
+      documentation: util.documentationForNode(node),
       signature: this._walkNode(node.type!),
     };
   }

--- a/test/integration/Emitter.ts
+++ b/test/integration/Emitter.ts
@@ -175,4 +175,59 @@ describe(`Emitter`, () => {
     const val = emitter._emitInterface(node, 'StarshipFederatedMultipleKeys');
     expect(val).to.eq(expected);
   });
+
+  it(`cost decoration field`, () => {
+    const expected =
+`type CostDecorationField {
+  bar: [String]
+  baz: Float @cost(useMultipliers: false, complexity: 2)
+}`;
+    const node = loadedTypes['CostDecorationField'] as types.InterfaceNode;
+    const val = emitter._emitInterface(node, 'CostDecorationField');
+    expect(val).to.eq(expected);
+  });
+
+  it(`cost decoration multiple fields`, () => {
+    const expected =
+`type CostDecorationMultipleFields {
+  bar: [String] @cost(useMultipliers: false, complexity: 2)
+  baz: Float @cost(useMultipliers: false, complexity: 2)
+}`;
+    const node = loadedTypes['CostDecorationMultipleFields'] as types.InterfaceNode;
+    const val = emitter._emitInterface(node, 'CostDecorationMultipleFields');
+    expect(val).to.eq(expected);
+  });
+
+  it(`cost decoration type`, () => {
+    const expected =
+`type CostDecorationType @cost(useMultipliers: false, complexity: 2) {
+  bar: [String]
+  baz: Float
+}`;
+    const node = loadedTypes['CostDecorationType'] as types.InterfaceNode;
+    const val = emitter._emitInterface(node, 'CostDecorationType');
+    expect(val).to.eq(expected);
+  });
+
+  it(`cost decoration field with key`, () => {
+    const expected =
+`type CostDecorationFieldWithKey @key(fields: "name") {
+  bar: [String]
+  baz: Float @cost(useMultipliers: false, complexity: 2)
+}`;
+    const node = loadedTypes['CostDecorationFieldWithKey'] as types.InterfaceNode;
+    const val = emitter._emitInterface(node, 'CostDecorationFieldWithKey');
+    expect(val).to.eq(expected);
+  });
+
+  it(`cost decoration type with key`, () => {
+    const expected =
+`type CostDecorationTypeWithKey @key(fields: "name") @cost(useMultipliers: false, complexity: 2) {
+  bar: [String]
+  baz: Float
+}`;
+    const node = loadedTypes['CostDecorationTypeWithKey'] as types.InterfaceNode;
+    const val = emitter._emitInterface(node, 'CostDecorationTypeWithKey');
+    expect(val).to.eq(expected);
+  });
 });

--- a/test/schema.ts
+++ b/test/schema.ts
@@ -36,6 +36,41 @@ export interface StarshipFederatedMultipleKeys {
   length:number;
 }
 
+export interface CostDecorationField {
+  bar:string[];
+  /** @graphql cost (useMultipliers: false, complexity: 2) */
+  baz:number;
+}
+
+export interface CostDecorationMultipleFields {
+  /** @graphql cost (useMultipliers: false, complexity: 2) */
+  bar:string[];
+  /** @graphql cost (useMultipliers: false, complexity: 2) */
+  baz:number;
+}
+
+/** @graphql cost (useMultipliers: false, complexity: 2) */
+export interface CostDecorationType {
+  bar:string[];
+  baz:number;
+}
+
+/** @graphql key name */
+export interface CostDecorationFieldWithKey {
+  bar:string[];
+  /** @graphql cost (useMultipliers: false, complexity: 2) */
+  baz:number;
+}
+
+/**
+ * @graphql cost (useMultipliers: false, complexity: 2)
+ * @graphql key name
+ */
+export interface CostDecorationTypeWithKey {
+  bar:string[];
+  baz:number;
+}
+
 export enum Color {
   'Red',
   'Yellow',
@@ -98,6 +133,11 @@ export interface QueryRoot {
   starshipFederated():StarshipFederated;
   starshipFederatedCompound():StarshipFederatedCompoundKey;
   starshipFederatedMultiple():StarshipFederatedMultipleKeys;
+  costDecorationField():CostDecorationField;
+  costDecorationMultipleFields():CostDecorationMultipleFields;
+  costDecorationType():CostDecorationType;
+  costDecorationFieldWithKey():CostDecorationFieldWithKey;
+  costDecorationTypeWithKey():CostDecorationTypeWithKey;
 }
 
 export interface MutationRoot {


### PR DESCRIPTION
I added support for @cost decoration in ts2gql by creating a helper function called _costHelper that returns a costDecorator string, which was added to the relevant return strings in _emitInterface.  The _costHelper function takes in a ComplexNode as input, so it works for both individual fields and general types

I tested these changes by adding the following tests to schema.ts:

export interface CostDecorationField {
  bar:string[];
  /** @graphql cost (useMultipliers: false, complexity: 2) */
  baz:number;
}

export interface CostDecorationMultipleFields {
  /** @graphql cost (useMultipliers: false, complexity: 2) */
  bar:string[];
  /** @graphql cost (useMultipliers: false, complexity: 2) */
  baz:number;
}

/** @graphql cost (useMultipliers: false, complexity: 2) */
export interface CostDecorationType {
  bar:string[];
  baz:number;
}

/** @graphql key name */
export interface CostDecorationFieldWithKey {
  bar:string[];
  /** @graphql cost (useMultipliers: false, complexity: 2) */
  baz:number;
}

/**
 * @graphql cost (useMultipliers: false, complexity: 2)
 * @graphql key name
 */
export interface CostDecorationTypeWithKey {
  bar:string[];
  baz:number;
}

These tests matched the following output, respectively:

`type CostDecorationField {\n
  bar: [String]\n
  baz: Float @cost(useMultipliers: false, complexity: 2)\n
}`

`type CostDecorationMultipleFields {\n
  bar: [String] @cost(useMultipliers: false, complexity: 2)\n
  baz: Float @cost(useMultipliers: false, complexity: 2)\n
}`

`type CostDecorationType @cost(useMultipliers: false, complexity: 2) {\n
  bar: [String]\n
  baz: Float\n
}`

`type CostDecorationFieldWithKey @key(fields: "name") {\n
  bar: [String]\n
  baz: Float @cost(useMultipliers: false, complexity: 2)\n
}`

`type CostDecorationTypeWithKey @key(fields: "name") @cost(useMultipliers: false, complexity: 2) {\n
  bar: [String]\n
  baz: Float\n
}`