### PR TITLE
Add @graphql non-nullable annotation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts2gql",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Converts a TypeScript type hierarchy into GraphQL's IDL.",
   "homepage": "https://github.com/convoyinc/ts2gql",
   "bugs": "https://github.com/convoyinc/ts2gql/issues",

--- a/test/integration/Emitter.ts
+++ b/test/integration/Emitter.ts
@@ -234,10 +234,10 @@ describe(`Emitter`, () => {
   it(`not-nullable types`, () => {
     const expected =
 `type NonNullableProperties {
-    nonNullArray: [String!]!
-    nonNullString: String!
-    nullableString: String
-    someMethod: [foo: String!]!
+  nonNullArray: [String!]!
+  nonNullString: String!
+  nullableString: String
+  someMethod: Starship!
 }`;
     const node = loadedTypes['NonNullableProperties'] as types.InterfaceNode;
     const val = emitter._emitInterface(node, 'NonNullableProperties');

--- a/test/integration/Emitter.ts
+++ b/test/integration/Emitter.ts
@@ -233,14 +233,14 @@ describe(`Emitter`, () => {
 
   it(`not-nullable types`, () => {
     const expected =
-`type NotNullableProperties {
-    nullableString: String
-    nonNullString: String!
+`type NonNullableProperties {
     nonNullArray: [String!]!
+    nonNullString: String!
+    nullableString: String
     someMethod: [foo: String!]!
 }`;
-    const node = loadedTypes['NotNullableProperties'] as types.InterfaceNode;
-    const val = emitter._emitInterface(node, 'NotNullableProperties');
+    const node = loadedTypes['NonNullableProperties'] as types.InterfaceNode;
+    const val = emitter._emitInterface(node, 'NonNullableProperties');
     expect(val).to.eq(expected);
   });
 });

--- a/test/integration/Emitter.ts
+++ b/test/integration/Emitter.ts
@@ -230,4 +230,17 @@ describe(`Emitter`, () => {
     const val = emitter._emitInterface(node, 'CostDecorationTypeWithKey');
     expect(val).to.eq(expected);
   });
+
+  it(`not-nullable types`, () => {
+    const expected =
+`type NotNullableProperties {
+    nullableString: String
+    nonNullString: String!
+    nonNullArray: [String!]!
+    someMethod: [foo: String!]!
+}`;
+    const node = loadedTypes['NotNullableProperties'] as types.InterfaceNode;
+    const val = emitter._emitInterface(node, 'NotNullableProperties');
+    expect(val).to.eq(expected);
+  });
 });

--- a/test/schema.ts
+++ b/test/schema.ts
@@ -71,7 +71,7 @@ export interface CostDecorationTypeWithKey {
   baz:number;
 }
 
-export interface NotNullableProperties {
+export interface NonNullableProperties {
   nullableString:string;
   /* @graphql non-nullable */
   nonNullString:string;
@@ -148,7 +148,7 @@ export interface QueryRoot {
   costDecorationType():CostDecorationType;
   costDecorationFieldWithKey():CostDecorationFieldWithKey;
   costDecorationTypeWithKey():CostDecorationTypeWithKey;
-  nonNullableProperties():NotNullableProperties;
+  nonNullableProperties():NonNullableProperties;
 }
 
 export interface MutationRoot {

--- a/test/schema.ts
+++ b/test/schema.ts
@@ -71,6 +71,16 @@ export interface CostDecorationTypeWithKey {
   baz:number;
 }
 
+export interface NotNullableProperties {
+  nullableString:string;
+  /* @graphql non-nullable */
+  nonNullString:string;
+  /* @graphql non-nullable */
+  nonNullArray:string[];
+  /* @graphql non-nullable */
+  someMethod(): { /* @graphql non-nullable */ foo: string}[];
+}
+
 export enum Color {
   'Red',
   'Yellow',
@@ -138,6 +148,7 @@ export interface QueryRoot {
   costDecorationType():CostDecorationType;
   costDecorationFieldWithKey():CostDecorationFieldWithKey;
   costDecorationTypeWithKey():CostDecorationTypeWithKey;
+  nonNullableProperties():NotNullableProperties;
 }
 
 export interface MutationRoot {

--- a/test/schema.ts
+++ b/test/schema.ts
@@ -78,7 +78,7 @@ export interface NonNullableProperties {
   /* @graphql non-nullable */
   nonNullArray:string[];
   /* @graphql non-nullable */
-  someMethod(): { /* @graphql non-nullable */ foo: string}[];
+  someMethod(): Starship;
 }
 
 export enum Color {


### PR DESCRIPTION
This adds an optional jsdoc-based "annotation", which instructs `ts2gql` to emit the `!` non-nullable operator.

This is in support of Connect federating with the Shipotle schema. We'd *really* like to tighten up Shipotle's graphql typings to remove some unnecessary nullness.