### PR TITLE
Support extending types and external/requires directives

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts2gql",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Converts a TypeScript type hierarchy into GraphQL's IDL.",
   "homepage": "https://github.com/convoyinc/ts2gql",
   "bugs": "https://github.com/convoyinc/ts2gql/issues",

--- a/test/integration/Emitter.ts
+++ b/test/integration/Emitter.ts
@@ -139,41 +139,52 @@ describe(`Emitter`, () => {
       const val = emitter._emitInterface(node, 'Starship');
       expect(val).to.eq(expected);
     });
-  });
 
-  it(`basic key decoration`, () => {
-    const expected =
+    it(`basic key decoration`, () => {
+      const expected =
 `type StarshipFederated @key(fields: "name") {
   length: Float
   name: String
 }`;
-    const node = loadedTypes['StarshipFederated'] as types.InterfaceNode;
-    const val = emitter._emitInterface(node, 'StarshipFederated');
-    expect(val).to.eq(expected);
-  });
+      const node = loadedTypes['StarshipFederated'] as types.InterfaceNode;
+      const val = emitter._emitInterface(node, 'StarshipFederated');
+      expect(val).to.eq(expected);
+    });
 
-  it(`compound key decoration`, () => {
-    const expected =
+    it(`compound key decoration`, () => {
+      const expected =
 `type StarshipFederatedCompoundKey @key(fields: "name id") {
   id: String
   length: Float
   name: String
 }`;
-    const node = loadedTypes['StarshipFederatedCompoundKey'] as types.InterfaceNode;
-    const val = emitter._emitInterface(node, 'StarshipFederatedCompoundKey');
-    expect(val).to.eq(expected);
-  });
+      const node = loadedTypes['StarshipFederatedCompoundKey'] as types.InterfaceNode;
+      const val = emitter._emitInterface(node, 'StarshipFederatedCompoundKey');
+      expect(val).to.eq(expected);
+    });
 
-  it(`multiple keys decoration`, () => {
-    const expected =
+    it(`multiple keys decoration`, () => {
+      const expected =
 `type StarshipFederatedMultipleKeys @key(fields: "name") @key(fields: "id") {
   id: String
   length: Float
   name: String
 }`;
-    const node = loadedTypes['StarshipFederatedMultipleKeys'] as types.InterfaceNode;
-    const val = emitter._emitInterface(node, 'StarshipFederatedMultipleKeys');
-    expect(val).to.eq(expected);
+      const node = loadedTypes['StarshipFederatedMultipleKeys'] as types.InterfaceNode;
+      const val = emitter._emitInterface(node, 'StarshipFederatedMultipleKeys');
+      expect(val).to.eq(expected);
+    });
+
+    it(`extending a foreign entity`, () => {
+      const expected =
+`extend type ExtendingExternalEntity @key(fields: "name") {
+  length: Float @requires(fields: "name")
+  name: String @external
+}`;
+      const node = loadedTypes['ExtendingExternalEntity'] as types.InterfaceNode;
+      const val = emitter._emitInterface(node, 'ExtendingExternalEntity');
+      expect(val).to.eq(expected);
+    });
   });
 
   it(`cost decoration field`, () => {

--- a/test/schema.ts
+++ b/test/schema.ts
@@ -71,6 +71,17 @@ export interface CostDecorationTypeWithKey {
   baz:number;
 }
 
+/**
+ * @graphql key name
+ * @graphql extend
+ */
+export interface ExtendingExternalEntity {
+  /** @graphql external */
+  name:string;
+  /** @graphql requires(fields: "name") */
+  length:number;
+}
+
 export interface NonNullableProperties {
   nullableString:string;
   /* @graphql non-nullable */
@@ -143,6 +154,7 @@ export interface QueryRoot {
   starshipFederated():StarshipFederated;
   starshipFederatedCompound():StarshipFederatedCompoundKey;
   starshipFederatedMultiple():StarshipFederatedMultipleKeys;
+  extendingExternalEntity():ExtendingExternalEntity;
   costDecorationField():CostDecorationField;
   costDecorationMultipleFields():CostDecorationMultipleFields;
   costDecorationType():CostDecorationType;


### PR DESCRIPTION
According to the [Apollo federation spec](https://www.apollographql.com/docs/federation/federation-spec/), GraphQL federation supports `extend`-ing types, as well as tagging members as `@external` and `@requires`. Here I implement support for those basic directives.

Tested with a new test case.